### PR TITLE
Make generated policy files reproducible

### DIFF
--- a/src/policy_ts_convert.py
+++ b/src/policy_ts_convert.py
@@ -137,7 +137,7 @@ def ts2policy(policyFile, tsDir, outputPolicyFile):
 
     for action_elem in tree.iter("action"):
         action = Action(action_elem)
-        for lang in tr_dict:
+        for lang in sorted(tr_dict):
             d = tr_dict[lang]
             src = ""
             for ty in ["description", "message"]:


### PR DESCRIPTION
To generate reproducible policy files on different filesystems the
Python dictionary has to be sorted when iterated over.