### PR TITLE
fix: remove depends python

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,6 @@ Depends:
  libconfig-tiny-perl,
  libxml-libxml-perl,
  perl,
- python,
  python3,
  ${misc:Depends},
 Description: Deepin Internationalization utilities

--- a/src/generate_mo.py
+++ b/src/generate_mo.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2015 Deepin Technology Co., Ltd.

--- a/src/update_pot.py
+++ b/src/update_pot.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2015 Deepin Technology Co., Ltd.


### PR DESCRIPTION
The debian repository has deleted python2 related packages, no longer supports python2, delete python2 related dependencies
